### PR TITLE
function to broadcast a signed tx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,3 +33,9 @@
 ##### Implement sign functionality
 
 - Added sign() to sign a message or transaction and get signature along with v,r,s.
+
+### 1.3.0 (2022-04-12)
+
+##### Implement transaction broadcast functionality
+
+- Added `sendTransaction()` function to send a signed transaction to the blockchain.

--- a/README.md
+++ b/README.md
@@ -78,3 +78,9 @@ const signedData = await ethController.signTypedMessage(msgParams);
 ```
 const balance = await getBalance(address, web3);
 ```
+
+### Send Transaction
+
+```
+const receipt = await ethController.signTypedMessage(signedTx, web3);
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getsafle/vault-eth-controller",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Ethereum controller for safle vault.",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -527,6 +527,11 @@ class KeyringController extends EventEmitter {
     this.memStore.updateState({ isUnlocked: true })
     this.emit('unlock')
   }
+
+  async sendTransaction(signedTx, web3) {
+    const receipt = await web3.eth.sendSignedTransaction(signedTx);
+    return { transactionDetails: receipt.transactionHash }
+  }
 }
 
 const getBalance = async (address, web3) => {


### PR DESCRIPTION
Added a function to broadcast a signed transaction.

Function name - `sendTransaction(signedTx, web3)`

Parameters :
1. `signedTx` - Signed transaction string
2. `web3` - Initialized web3 object